### PR TITLE
remove .Net 5 requirement

### DIFF
--- a/articles/defender-for-cloud/azure-devops-extension.md
+++ b/articles/defender-for-cloud/azure-devops-extension.md
@@ -102,10 +102,6 @@ If you don't have access to install the extension, you must request access from 
     - task: UseDotNet@2
       displayName: 'Use dotnet'
       inputs:
-        version: 5.0.x
-    - task: UseDotNet@2
-      displayName: 'Use dotnet'
-      inputs:
         version: 6.0.x
     - task: MicrosoftSecurityDevOps@1
       displayName: 'Microsoft Security DevOps'


### PR DESCRIPTION
Dotnet 5 is not needed, and should not be included in the pipeline.

This change makes the docs document mirror [GitHub](https://github.com/microsoft/security-devops-azdevops#dependencies) and the [marketplace documentation](https://marketplace.visualstudio.com/items?itemName=ms-securitydevops.microsoft-security-devops-azdevops)